### PR TITLE
Update ESLint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -36,6 +36,7 @@ module.exports = {
   plugins: ['react-hooks'],
   root: true,
   rules: {
+    '@typescript-eslint/explicit-function-return-type': 'off',
     'no-console': process.env.NODE_ENV === 'development' ? 'off' : 'error',
     'no-debugger': process.env.NODE_ENV === 'development' ? 'off' : 'error',
     'react-hooks/exhaustive-deps': 'warn',


### PR DESCRIPTION
型推論の効く関数であっても返り値の型の指定がないと警告が出てしまうため `@typescript-eslint/explicit-function-return-type` の設定をオフにしました。

- [typescript-eslint/explicit-function-return-type.md at master · typescript-eslint/typescript-eslint](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/explicit-function-return-type.md)