### PR TITLE
Add path aliases for module import

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -20,7 +20,7 @@ module.exports = {
   },
   overrides: [
     {
-      files: ['./frontend/next.config.js'],
+      files: ['./frontend/next.config.js', './jest.config.js'],
       rules: {
         '@typescript-eslint/no-var-requires': 'off'
       }

--- a/backend/server.ts
+++ b/backend/server.ts
@@ -1,4 +1,4 @@
-import app from './app'
+import app from 'backend/app'
 
 const { NODE_ENV, PORT } = process.env
 

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,9 +1,21 @@
 const path = require('path')
 const withTypescript = require('@zeit/next-typescript')
 const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin')
+const { compilerOptions } = require('../tsconfig')
+
+const baseUrl = path.resolve(process.cwd(), compilerOptions.baseUrl)
 
 module.exports = withTypescript({
   webpack(config, { dev, isServer }) {
+    config.resolve.alias = {
+      ...config.resolve.alias,
+      ...Object.entries(compilerOptions.paths).reduce((obj, cv) => {
+        const reg = new RegExp('\\/?\\*$')
+        obj[cv[0].replace(reg, '')] = path.join(baseUrl, cv[1][0].replace(reg, ''))
+        return obj
+      }, {})
+    }
+
     if (dev && isServer) {
       config.module.rules.push({
         enforce: 'pre',

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -2,9 +2,9 @@ import Link from 'next/link'
 import React from 'react'
 import styled from 'styled-components'
 import { Alert, Container, Col as GridCol, Row as GridRow } from 'react-bootstrap'
-import ExampleModal from '../components/exampleModal'
-import Head from '../components/head'
-import Nav from '../components/nav'
+import ExampleModal from 'components/exampleModal'
+import Head from 'components/head'
+import Nav from 'components/nav'
 
 const Hero = styled.div`
   width: 100%;

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,26 @@
+const path = require('path')
+const { compilerOptions } = require('./tsconfig')
+
+const baseUrl = path.resolve(process.cwd(), compilerOptions.baseUrl)
+
 module.exports = {
   preset: 'ts-jest',
-  testEnvironment: 'node'
+  testEnvironment: 'node',
+  moduleNameMapper: {
+    ...Object.entries(compilerOptions.paths).reduce((obj, cv) => {
+      const reg = new RegExp('\\/?\\*$')
+      const key = cv[0].replace(reg, '')
+      const value = cv[1][0].replace(reg, '')
+
+      if (/^.*(?<!\/\*)$/.test(cv[0])) {
+        obj[`^${key}$`] = `${path.join(baseUrl, value)}`
+      }
+
+      if (/\*$/.test(cv[0])) {
+        obj[`^${key}/(.*)`] = `${path.join(baseUrl, value)}/$1`
+      }
+
+      return obj
+    }, {})
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1243,6 +1243,12 @@
       "integrity": "sha512-yALhelO3i0hqZwhjtcr6dYyaLoCHbAMshwtj6cGxTvHZAKXHsYGdff6E8EPw3xLKY0ELUTQ69Q1rQiJENnccMA==",
       "dev": true
     },
+    "@types/json5": {
+      "version": "0.0.29",
+      "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
+      "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
+      "dev": true
+    },
     "@types/minimatch": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
@@ -3457,6 +3463,12 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+      "dev": true
+    },
+    "deepmerge": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-2.2.1.tgz",
+      "integrity": "sha512-R9hc1Xa/NOBi9WRVUWg19rl1UB7Tt4kuPd+thNJgFZoxXsTz7ncaPaeIm+40oSGuP33DfMb4sZt1QIGiJzC4EA==",
       "dev": true
     },
     "define-properties": {
@@ -11002,6 +11014,36 @@
         "make-error": "^1.1.1",
         "source-map-support": "^0.5.6",
         "yn": "^3.0.0"
+      }
+    },
+    "tsconfig-paths": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.8.0.tgz",
+      "integrity": "sha512-zZEYFo4sjORK8W58ENkRn9s+HmQFkkwydDG7My5s/fnfr2YYCaiyXe/HBUcIgU8epEKOXwiahOO+KZYjiXlWyQ==",
+      "dev": true,
+      "requires": {
+        "@types/json5": "^0.0.29",
+        "deepmerge": "^2.0.1",
+        "json5": "^1.0.1",
+        "minimist": "^1.2.0",
+        "strip-bom": "^3.0.0"
+      },
+      "dependencies": {
+        "json5": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+          "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.0"
+          }
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
       }
     },
     "tslib": {

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "supertest": "4.0.2",
     "ts-jest": "24.0.2",
     "ts-node": "8.3.0",
+    "tsconfig-paths": "3.8.0",
     "typescript": "3.5.2"
   },
   "babel": {
@@ -104,7 +105,7 @@
       "NODE_ENV": "development",
       "PORT": 8000
     },
-    "exec": "ts-node backend/server.ts",
+    "exec": "ts-node --require tsconfig-paths/register backend/server.ts",
     "ext": "ts",
     "watch": [
       "backend"

--- a/specs/backend/index.spec.ts
+++ b/specs/backend/index.spec.ts
@@ -1,5 +1,5 @@
 import request from 'supertest'
-import app from '../../backend/app'
+import app from 'backend/app'
 
 describe('/', () => {
   it('GET request', async () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "allowJs": true,
     "allowSyntheticDefaultImports": true,
+    "baseUrl": "./",
     "emitDecoratorMetadata": true,
     "esModuleInterop": true,
     "experimentalDecorators": true,
@@ -12,6 +13,15 @@
     "noEmit": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
+    "paths": {
+      "backend/*": ["./backend/*"],
+      "components/*": ["./frontend/components/*"],
+      "frontend/*": ["./frontend/*"],
+      "pages/*": ["./frontend/pages/*"],
+      "specs/*": ["./specs/*"],
+      "static/*": ["./frontend/static/*"],
+      "~/*": ["./*"]
+    },
     "preserveConstEnums": true,
     "removeComments": false,
     "skipLibCheck": true,


### PR DESCRIPTION
`import` 文などで相対パスではなくエイリアスを使ってパスを指定できるように設定を追加しました。  
登録しているエイリアスは以下の通りです。  
\*`/index` は明示的に指定した方がよいと思い省略の設定はしていません。

- `tsconfig.json`

  ```js
  {
    "compilerOptions": {
      // ...
      "paths": {
        "backend/*": ["./backend/*"],
        "components/*": ["./frontend/components/*"],
        "frontend/*": ["./frontend/*"],
        "pages/*": ["./frontend/pages/*"],
        "specs/*": ["./specs/*"],
        "static/*": ["./frontend/static/*"],
        "~/*": ["./*"]
      },
      // ...
    }
  }
  ```

- [Next.js](https://nextjs.org/)
  - [webpack](https://webpack.js.org/) の設定を拡張
    - <https://github.com/zeit/next.js/blob/master/examples/with-absolute-imports/next.config.js>
    - [Resolve | webpack](https://webpack.js.org/configuration/resolve/#resolvealias)
- [ts-node](https://github.com/TypeStrong/ts-node)
  - [ts-node](https://github.com/TypeStrong/ts-node) は `tsconfig.json` の `compilerOptions.paths` を自動変換しないため [`tsconfig-paths`](https://github.com/dividab/tsconfig-paths) を利用
    - <https://github.com/dividab/tsconfig-paths#with-ts-node>
- [Jest](https://jestjs.io/en/)
  - `moduleNameMapper` のオプションを追加
    - <https://jestjs.io/docs/en/configuration#modulenamemapper-object-string-string>
