### PR TITLE
Fix Next.js error on Windows

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,17 +1,27 @@
+require('dotenv').config()
+
 const path = require('path')
-const withTypescript = require('@zeit/next-typescript')
+const Dotenv = require('dotenv-webpack')
 const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin')
+const withTypescript = require('@zeit/next-typescript')
 const { compilerOptions } = require('../tsconfig')
 
 const baseUrl = path.resolve(process.cwd(), compilerOptions.baseUrl)
 
 module.exports = withTypescript({
   webpack(config, { dev, isServer }) {
+    config.plugins = [
+      ...(config.plugins || []),
+      new Dotenv({
+        path: path.resolve(__dirname, '../.env')
+      })
+    ]
+
     config.resolve.alias = {
       ...config.resolve.alias,
       ...Object.entries(compilerOptions.paths).reduce((obj, cv) => {
         const reg = new RegExp('\\/?\\*$')
-        obj[cv[0].replace(reg, '')] = path.join(baseUrl, cv[1][0].replace(reg, ''))
+        obj[cv[0].replace(reg, '')] = path.resolve(baseUrl, cv[1][0].replace(reg, ''))
         return obj
       }, {})
     }
@@ -28,7 +38,7 @@ module.exports = withTypescript({
     if (isServer) {
       config.plugins.push(
         new ForkTsCheckerWebpackPlugin({
-          tsconfig: path.join(__dirname, './tsconfig.json')
+          tsconfig: path.resolve(__dirname, './tsconfig.json')
         })
       )
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3628,6 +3628,32 @@
       "integrity": "sha512-30xVGqjLjiUOArT4+M5q9sYdvuR4riM6yK9wMcas9Vbp6zZa+ocC9dp6QoftuhTPhFAiLK/0C5Ni2nou/Bk8lg==",
       "dev": true
     },
+    "dotenv-defaults": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/dotenv-defaults/-/dotenv-defaults-1.0.2.tgz",
+      "integrity": "sha512-iXFvHtXl/hZPiFj++1hBg4lbKwGM+t/GlvELDnRtOFdjXyWP7mubkVr+eZGWG62kdsbulXAef6v/j6kiWc/xGA==",
+      "dev": true,
+      "requires": {
+        "dotenv": "^6.2.0"
+      },
+      "dependencies": {
+        "dotenv": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-6.2.0.tgz",
+          "integrity": "sha512-HygQCKUBSFl8wKQZBSemMywRWcEDNidvNbjGVyZu3nbZ8qq9ubiPoGLMdRDpfSrpkkm9BXYFkpKxxFX38o/76w==",
+          "dev": true
+        }
+      }
+    },
+    "dotenv-webpack": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/dotenv-webpack/-/dotenv-webpack-1.7.0.tgz",
+      "integrity": "sha512-wwNtOBW/6gLQSkb8p43y0Wts970A3xtNiG/mpwj9MLUhtPCQG6i+/DSXXoNN7fbPCU/vQ7JjwGmgOeGZSSZnsw==",
+      "dev": true,
+      "requires": {
+        "dotenv-defaults": "^1.0.2"
+      }
+    },
     "duplexer3": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "homepage": "https://github.com/8k-eagle-eye/eagle-eye#readme",
   "scripts": {
     "dev": "npm-run-all --parallel dev:*",
-    "dev:client": "node --require dotenv/config node_modules/.bin/next frontend",
+    "dev:client": "next frontend",
     "dev:server": "nodemon",
     "build": "next build frontend",
     "start": "next start frontend",
@@ -47,6 +47,7 @@
     "babel-plugin-styled-components": "1.10.6",
     "codecov": "3.5.0",
     "dotenv": "8.0.0",
+    "dotenv-webpack": "1.7.0",
     "eslint": "6.0.1",
     "eslint-config-prettier": "6.0.0",
     "eslint-config-standard": "12.0.0",


### PR DESCRIPTION
[Next.js](https://nextjs.org/) を `next` コマンドではなく `node node_modules/.bin/next` で実行すると Windows のみ以下のエラーが発生していました。

```bat
> node node_modules/.bin/next frontend

C:\Users\User\eagle-eye\node_modules\.bin\next:2
basedir=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')")
          ^^^^^^^

SyntaxError: missing ) after argument list
    at new Script (vm.js:79:7)
    at createScript (vm.js:251:10)
    at Object.runInThisContext (vm.js:303:10)
    at Module._compile (internal/modules/cjs/loader.js:657:28)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:700:10)
    at Module.load (internal/modules/cjs/loader.js:599:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:538:12)
    at Function.Module._load (internal/modules/cjs/loader.js:530:3)
    at Function.Module.runMain (internal/modules/cjs/loader.js:742:12)
    at startup (internal/bootstrap/node.js:283:19)
```

[zeit/next.js/examples/with-dotenv](https://github.com/zeit/next.js/tree/canary/examples/with-dotenv) を参考に [`dotenv`](https://github.com/motdotla/dotenv) を npm run-script ではなくプログラムの中で利用するように修正しました。

- [next.js/examples/with-dotenv at canary · zeit/next.js](https://github.com/zeit/next.js/tree/canary/examples/with-dotenv)
- [next.js/next.config.js at canary · zeit/next.js](https://github.com/zeit/next.js/blob/canary/examples/with-dotenv/next.config.js)
