### PR TITLE
単純な動画再生のみ対応

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+STORAGE_ORIGIN=<AWS S3 URL of videos>

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -38,6 +38,7 @@ module.exports = {
   root: true,
   rules: {
     '@typescript-eslint/explicit-function-return-type': 'off',
+    '@typescript-eslint/no-non-null-assertion': 'off',
     'no-console': process.env.NODE_ENV === 'development' ? 'off' : 'error',
     'no-debugger': process.env.NODE_ENV === 'development' ? 'off' : 'error',
     'react-hooks/exhaustive-deps': 'warn',

--- a/frontend/components/viewer/index.tsx
+++ b/frontend/components/viewer/index.tsx
@@ -1,0 +1,74 @@
+import React, { FC, useState, useCallback, createRef } from 'react'
+import styled from 'styled-components'
+
+interface ViewerProps {
+  aspect: number
+}
+
+const ViewerRoot = styled.div`
+  padding-top: ${({ aspect }: Pick<ViewerProps, 'aspect'>) => 100 / aspect}%;
+  position: relative;
+`
+
+const MediaFrame = styled.div`
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  left: 0;
+  top: 0;
+  transform-origin: left top;
+`
+
+const BaseVideo = styled.video`
+  vertical-align: bottom;
+  width: 100%;
+`
+
+const PlayIcon = styled.div`
+  position: absolute;
+  bottom: 15px;
+  left: 15px;
+  background: #ffffffaa;
+  border-radius: 10px;
+  cursor: pointer;
+  padding: 5px 15px;
+  font-size: 20px;
+
+  &:hover {
+    background: #fff;
+  }
+`
+
+const Viewer: FC<ViewerProps> = props => {
+  const videoRef = createRef<HTMLVideoElement>()
+  const [playing, setPlaying] = useState(false)
+  const togglePlaying = useCallback(() => {
+    const video = videoRef.current
+    if (!video) return
+
+    if (video.paused) {
+      video.play()
+      setPlaying(true)
+    } else {
+      video.pause()
+      setPlaying(false)
+    }
+  }, [videoRef])
+
+  return (
+    <ViewerRoot aspect={props.aspect}>
+      <MediaFrame>
+        <BaseVideo
+          ref={videoRef}
+          src={`${process.env.STORAGE_ORIGIN}/videos/hd/1-1.mp4`}
+          loop
+          playsInline
+        />
+      </MediaFrame>
+
+      <PlayIcon onClick={togglePlaying}>{playing ? '■' : '▶'}</PlayIcon>
+    </ViewerRoot>
+  )
+}
+
+export default Viewer

--- a/frontend/components/viewer/index.tsx
+++ b/frontend/components/viewer/index.tsx
@@ -1,12 +1,12 @@
-import React, { FC, useState, useCallback, createRef } from 'react'
+import React, { useState, createRef } from 'react'
 import styled from 'styled-components'
 
 interface ViewerProps {
   aspect: number
 }
 
-const ViewerRoot = styled.div`
-  padding-top: ${({ aspect }: Pick<ViewerProps, 'aspect'>) => 100 / aspect}%;
+const ViewerRoot = styled.div<{ aspect: number }>`
+  padding-top: ${({ aspect }) => 100 / aspect}%;
   position: relative;
 `
 
@@ -39,12 +39,11 @@ const PlayIcon = styled.div`
   }
 `
 
-const Viewer: FC<ViewerProps> = props => {
+const Viewer = (props: ViewerProps) => {
   const videoRef = createRef<HTMLVideoElement>()
   const [playing, setPlaying] = useState(false)
-  const togglePlaying = useCallback(() => {
-    const video = videoRef.current
-    if (!video) return
+  const togglePlaying = () => {
+    const video = videoRef.current!
 
     if (video.paused) {
       video.play()
@@ -53,7 +52,7 @@ const Viewer: FC<ViewerProps> = props => {
       video.pause()
       setPlaying(false)
     }
-  }, [videoRef])
+  }
 
   return (
     <ViewerRoot aspect={props.aspect}>

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -5,6 +5,7 @@ import { Alert, Container, Col as GridCol, Row as GridRow } from 'react-bootstra
 import ExampleModal from 'components/exampleModal'
 import Head from 'components/head'
 import Nav from 'components/nav'
+import Viewer from 'components/viewer'
 
 const Hero = styled.div`
   width: 100%;
@@ -23,6 +24,11 @@ const Title = styled.h1`
 
 const Description = styled.p`
   text-align: center;
+`
+
+const ViewerFrame = styled.div`
+  width: 600px;
+  margin: 30px auto;
 `
 
 const Row = styled.div`
@@ -80,6 +86,10 @@ const Home = () => (
       <Description>
         To get started, edit <code>pages/index.js</code> and save to reload.
       </Description>
+
+      <ViewerFrame>
+        <Viewer aspect={16 / 9} />
+      </ViewerFrame>
 
       <Row>
         <Link href="https://github.com/zeit/next.js#getting-started">


### PR DESCRIPTION
- ボタンクリックで動画が再生と停止を繰り返すのみ（.envにS3のオリジンがないと動作しない）
- Hooksの使い方が適切か見て欲しい
- Viewerコンポーネントにはいずれsetting.jsonのパスを渡すだけであらゆるサイトで使えるように分離したい
- 動画リストの仕様が決まってないのでパスは一旦ハードコーディング

![無題](https://user-images.githubusercontent.com/9402912/61131581-9036d980-a4f4-11e9-937d-1587820d84d3.jpg)
