### PR TITLE
グリッドに吸いつく機能

### DIFF
--- a/frontend/consts/viewer.ts
+++ b/frontend/consts/viewer.ts
@@ -1,2 +1,4 @@
 export const MAX_SCALE = 12
 export const ZOOM_STEP = 0.4
+export const GRID_ANIMATION_STEP = 20
+export const DELAY_ANIMATION_ON_ZOOM = 200


### PR DESCRIPTION
- ズームとパンをした際に動画の解像度（resolutionRatio: 1K/2K/4K/8K）に応じたGridに吸着する機能を実装
- stateのfinallyTranslateは次のPRで子コンポーネントが使う
- ズームしたときにすぐ吸着するとガタツキがひどいのでDELAY_ANIMATION_ON_ZOOMで遅延させる
- get resolutionRatioの定義、requestAnimationFrame/setTimeoutのID管理が適切か確認して欲しい
![無題](https://user-images.githubusercontent.com/9402912/61310871-238f4800-a830-11e9-9614-82d3855ea27f.jpg)
