### PR TITLE
Add bot for dependency update

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,12 @@
+version: 1
+
+update_configs:
+  - package_manager: "javascript"
+    directory: "/"
+    update_schedule: "live"
+    allowed_updates:
+      - match:
+          update_type: "security"
+    commit_message:
+      prefix: "chore"
+      include_scope: true

--- a/README.md
+++ b/README.md
@@ -2,22 +2,29 @@
 
 <p align="center">
   <a href="https://circleci.com/gh/8k-eagle-eye/eagle-eye">
-    <img src="https://img.shields.io/circleci/build/github/8k-eagle-eye/eagle-eye.svg?style=flat-square&logo=circleci" alt="CircleCI" />
+    <img src="https://img.shields.io/circleci/build/github/8k-eagle-eye/eagle-eye.svg?label=test&logo=circleci" alt="CircleCI" />
   </a>
   <a href="https://codecov.io/gh/8k-eagle-eye/eagle-eye">
-    <img src="https://img.shields.io/codecov/c/github/8k-eagle-eye/eagle-eye.svg?style=flat-square&logo=codecov&logoColor=fff" alt="Codecov" />
+    <img src="https://img.shields.io/codecov/c/github/8k-eagle-eye/eagle-eye.svg?logo=codecov&logoColor=fff" alt="Codecov" />
   </a>
+  <a href="https://dependabot.com/">
+    <img src="https://badgen.net/dependabot/8k-eagle-eye/eagle-eye?icon=dependabot&label=dependabot" alt="Dependabot" />
+  </a>
+  <a href="https://renovatebot.com/">
+    <img src="https://badges.renovateapi.com/github/8k-eagle-eye/eagle-eye" alt="Renovate" />
+  </a>
+  <br />
   <a href="https://github.com/microsoft/TypeScript">
-    <img src="https://img.shields.io/npm/types/typescript.svg?style=flat-square&logo=typescript" alt="TypeScript"/>
+    <img src="https://img.shields.io/npm/types/typescript.svg?logo=typescript" alt="TypeScript"/>
   </a>
   <a href="https://github.com/standard/standard">
-    <img src="https://img.shields.io/badge/code_style-Standard-4b32c3.svg?style=flat-square&logo=eslint" alt="code style JavaScript Standard Style" />
+    <img src="https://img.shields.io/badge/code_style-Standard-4b32c3.svg?logo=eslint" alt="code style JavaScript Standard Style" />
   </a>
   <a href="https://github.com/prettier/prettier">
-    <img src="https://img.shields.io/badge/code_style-Prettier-ff69b4.svg?style=flat-square&logo=prettier&logoColor=fff" alt="code style Prettier"/>
+    <img src="https://img.shields.io/badge/code_style-Prettier-ff69b4.svg?logo=prettier&logoColor=fff" alt="code style Prettier"/>
   </a>
   <a href="https://github.com/facebook/jest">
-    <img src="https://img.shields.io/badge/tested_with-Jest-99424f.svg?style=flat-square&logo=jest" alt="tested with Jest"/>
+    <img src="https://img.shields.io/badge/tested_with-Jest-99424f.svg?logo=jest" alt="tested with Jest"/>
   </a>
 </p>
 

--- a/package.json
+++ b/package.json
@@ -138,5 +138,39 @@
         }
       }
     ]
+  },
+  "renovate": {
+    "description": "Configuration for 8K Eagle Eye",
+    "extends": [
+      "config:base",
+      ":timezone(Asia/Tokyo)"
+    ],
+    "npm": {
+      "commitMessageTopic": "{{prettyDepType}} {{depName}}",
+      "extends": [
+        "group:allNonMajor",
+        ":label(dependencies)",
+        ":prNotPending",
+        ":rebaseStalePrs",
+        ":semanticCommitTypeAll(chore)",
+        ":semanticCommits",
+        ":unpublishSafe"
+      ],
+      "lockFileMaintenance": {
+        "enabled": true,
+        "schedule": "after 10am on the first day of the month"
+      },
+      "prBodyColumns": [
+        "Package",
+        "Update",
+        "Type",
+        "Change",
+        "CompatibilityScore"
+      ],
+      "prBodyDefinitions": {
+        "CompatibilityScore": "[![compatibility-score for {{{depNameEscaped}}}](https://api.dependabot.com/badges/compatibility_score?dependency-name={{{depNameEscaped}}}&package-manager=npm_and_yarn&previous-version={{{fromVersion}}}&new-version={{{toVersion}}})](https://dependabot.com/compatibility-score/?dependency-name={{{depNameEscaped}}}&package-manager=npm_and_yarn&previous-version={{{fromVersion}}}&new-version={{{toVersion}}})"
+      }
+    },
+    "schedule": "after 10am on Saturday"
   }
 }


### PR DESCRIPTION
依存パッケージの更新を効率化するため [Dependabot](https://dependabot.com/) と [Renovate](https://renovatebot.com/) の設定ファイルを追加しました。  
それぞれの GitHub Apps はマージ後に連携します。

### [Dependabot](https://dependabot.com/)

- `package-lock.json` を含め、セキュリティに問題のあるパッケージがないかリアルタイムで監視します。

### [Renovate](https://renovatebot.com/)

- 週に 1 度、依存パッケージの更新有無を確認します。
  - 毎週土曜午前 10 時以降に設定しています。
- 月に 1 度、 `package-lock.json` のメンテナンスを行います。
  - 毎月 1 日午前 10 時以降に設定しています。
- メジャーアップデートは個別にプルリクエストを送信しますが、マイナー以下のバージョンのアップデートはひとつにまとめてプルリクエストを送信します。
- 判断基準としてプルリクエストの本文に [Dependabot](https://dependabot.com/) の [Compatibility score](https://dependabot.com/compatibility-score/) をバッチで表示するようにしています。

なお [8k-eagle-eye/eagle-eye](https://github.com/8k-eagle-eye/eagle-eye) はプルリクエストに対し、マージ前のレビューを必須にしているため手動での確認が必須になります。
