### PR TITLE
Grid吸着機能

### DIFF
--- a/frontend/components/viewer/frontVideo.tsx
+++ b/frontend/components/viewer/frontVideo.tsx
@@ -6,9 +6,10 @@ import useFrontVideoController from 'hooks/viewer/useFrontVideoController'
 interface FrontVideoProps {
   playing: boolean
   currentTime: number
-  baseSize: { width: number; height: number }
   scale: number
-  translate: { x: number; y: number }
+  gridSize: { width: number; height: number }
+  resolutionRatio: number
+  finallyTranslate: { x: number; y: number }
 }
 
 interface FrontVideoElemProps {
@@ -33,8 +34,13 @@ const FrontVideoElem = styled.video.attrs(
 `
 
 const FrontVideo = (props: FrontVideoProps) => {
-  const { playing, currentTime, baseSize, scale, translate } = props
-  const { resolutionRatio, top, left, src } = calculateFrontVideoParams(baseSize, scale, translate)
+  const { playing, currentTime, scale, gridSize, resolutionRatio, finallyTranslate } = props
+  const { top, left, src } = calculateFrontVideoParams(
+    gridSize,
+    resolutionRatio,
+    scale,
+    finallyTranslate
+  )
   const { ref, canPlay, setCanPlayOnCanPlayThrough } = useFrontVideoController(
     src,
     playing,

--- a/frontend/components/viewer/frontVideo.tsx
+++ b/frontend/components/viewer/frontVideo.tsx
@@ -9,7 +9,7 @@ interface FrontVideoProps {
   scale: number
   gridSize: { width: number; height: number }
   resolutionRatio: number
-  finallyTranslate: { x: number; y: number }
+  destinationTranslate: { x: number; y: number }
 }
 
 interface FrontVideoElemProps {
@@ -34,12 +34,12 @@ const FrontVideoElem = styled.video.attrs(
 `
 
 const FrontVideo = (props: FrontVideoProps) => {
-  const { playing, currentTime, scale, gridSize, resolutionRatio, finallyTranslate } = props
+  const { playing, currentTime, scale, gridSize, resolutionRatio, destinationTranslate } = props
   const { top, left, src } = calculateFrontVideoParams(
     gridSize,
     resolutionRatio,
     scale,
-    finallyTranslate
+    destinationTranslate
   )
   const { ref, canPlay, setCanPlayOnCanPlayThrough } = useFrontVideoController(
     src,

--- a/frontend/components/viewer/index.tsx
+++ b/frontend/components/viewer/index.tsx
@@ -35,7 +35,7 @@ const Viewer = (props: ViewerProps) => {
   const [clientRect, setClientRect] = useState({ top: 0, left: 0 })
   const [scale, setScale] = useState(1)
   const [translate, setTranslate] = useState({ x: 0, y: 0 })
-  const [finallyTranslate, setFinallyTranslate] = useState({ x: 0, y: 0 })
+  const [destinationTranslate, setFinallyTranslate] = useState({ x: 0, y: 0 })
   const [playing, setPlaying] = useState(false)
   const resolutionRatio = useMemo(() => (scale >= 8 ? 8 : scale >= 4 ? 4 : scale >= 2 ? 2 : 1), [
     scale
@@ -74,7 +74,7 @@ const Viewer = (props: ViewerProps) => {
         gridSize={gridSize}
         resolutionRatio={resolutionRatio}
         translate={translate}
-        finallyTranslate={finallyTranslate}
+        destinationTranslate={destinationTranslate}
       />
       <InputPanel
         baseSize={baseSize}
@@ -82,7 +82,7 @@ const Viewer = (props: ViewerProps) => {
         scale={scale}
         gridSize={gridSize}
         translate={translate}
-        finallyTranslate={finallyTranslate}
+        destinationTranslate={destinationTranslate}
         onChangeScale={setScale}
         onChangeTranslate={setTranslate}
         onChangeFinallyTranslate={setFinallyTranslate}

--- a/frontend/components/viewer/index.tsx
+++ b/frontend/components/viewer/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useEffect, createRef } from 'react'
+import React, { useState, useCallback, useEffect, createRef, useMemo } from 'react'
 import styled from 'styled-components'
 import VideoContainer from './videoContainer'
 import InputPanel from './inputPanel'
@@ -35,7 +35,18 @@ const Viewer = (props: ViewerProps) => {
   const [clientRect, setClientRect] = useState({ top: 0, left: 0 })
   const [scale, setScale] = useState(1)
   const [translate, setTranslate] = useState({ x: 0, y: 0 })
+  const [finallyTranslate, setFinallyTranslate] = useState({ x: 0, y: 0 })
   const [playing, setPlaying] = useState(false)
+  const resolutionRatio = useMemo(() => (scale >= 8 ? 8 : scale >= 4 ? 4 : scale >= 2 ? 2 : 1), [
+    scale
+  ])
+  const gridSize = useMemo(
+    () => ({
+      width: (baseSize.width * scale) / resolutionRatio / 2,
+      height: (baseSize.height * scale) / resolutionRatio / 2
+    }),
+    [baseSize, scale]
+  )
 
   const togglePlaying = useCallback(() => setPlaying(!playing), [playing])
 
@@ -57,14 +68,24 @@ const Viewer = (props: ViewerProps) => {
 
   return (
     <ViewerRoot ref={viewerRef} aspect={aspect}>
-      <VideoContainer playing={playing} baseSize={baseSize} scale={scale} translate={translate} />
+      <VideoContainer
+        playing={playing}
+        scale={scale}
+        gridSize={gridSize}
+        resolutionRatio={resolutionRatio}
+        translate={translate}
+        finallyTranslate={finallyTranslate}
+      />
       <InputPanel
         baseSize={baseSize}
         clientRect={clientRect}
         scale={scale}
+        gridSize={gridSize}
         translate={translate}
+        finallyTranslate={finallyTranslate}
         onChangeScale={setScale}
         onChangeTranslate={setTranslate}
+        onChangeFinallyTranslate={setFinallyTranslate}
       />
       <PlayIcon onClick={togglePlaying}>{playing ? '■' : '▶'}</PlayIcon>
     </ViewerRoot>

--- a/frontend/components/viewer/inputPanel.tsx
+++ b/frontend/components/viewer/inputPanel.tsx
@@ -9,7 +9,7 @@ interface InputPanelProps {
   scale: number
   gridSize: { width: number; height: number }
   translate: { x: number; y: number }
-  finallyTranslate: { x: number; y: number }
+  destinationTranslate: { x: number; y: number }
   onChangeScale: Dispatch<number>
   onChangeTranslate: Dispatch<{ x: number; y: number }>
   onChangeFinallyTranslate: Dispatch<{ x: number; y: number }>
@@ -150,10 +150,10 @@ export default class InputPanel extends Component<InputPanelProps> {
   }
 
   private runGridAnimation = () => {
-    const { translate, finallyTranslate } = this.props
+    const { translate, destinationTranslate } = this.props
     const step = GRID_ANIMATION_STEP
-    const diffXToGrid = translate.x - finallyTranslate.x
-    const diffYToGrid = translate.y - finallyTranslate.y
+    const diffXToGrid = translate.x - destinationTranslate.x
+    const diffYToGrid = translate.y - destinationTranslate.y
 
     const newDiffX =
       Math.abs(diffXToGrid) <= step ? 0 : diffXToGrid + (diffXToGrid < 0 ? step : -step)

--- a/frontend/components/viewer/inputPanel.tsx
+++ b/frontend/components/viewer/inputPanel.tsx
@@ -1,15 +1,18 @@
 import React, { Component, createRef, Dispatch } from 'react'
 import styled from 'styled-components'
-import { ZOOM_STEP, MAX_SCALE } from 'consts/viewer'
+import { ZOOM_STEP, MAX_SCALE, GRID_ANIMATION_STEP, DELAY_ANIMATION_ON_ZOOM } from 'consts/viewer'
 import calculateDistance from 'libs/viewer/calculateDistance'
 
 interface InputPanelProps {
   baseSize: { width: number; height: number }
   clientRect: { top: number; left: number }
   scale: number
+  gridSize: { width: number; height: number }
   translate: { x: number; y: number }
+  finallyTranslate: { x: number; y: number }
   onChangeScale: Dispatch<number>
   onChangeTranslate: Dispatch<{ x: number; y: number }>
+  onChangeFinallyTranslate: Dispatch<{ x: number; y: number }>
 }
 
 const InputPanelElem = styled.div`
@@ -27,6 +30,8 @@ export default class InputPanel extends Component<InputPanelProps> {
   private zooming = false
   private baseDistance = 0
   private inputPanelRef = createRef<HTMLDivElement>()
+  private timeoutId: number | null = null
+  private animationFrameId: number | null = null
 
   private onMouseDown = (e: React.MouseEvent) => {
     e.preventDefault()
@@ -67,20 +72,27 @@ export default class InputPanel extends Component<InputPanelProps> {
 
   private onMouseUp = () => {
     this.panning = false
+    this.startMoveToGrid()
   }
 
   private onTouchEnd = ({ touches }: TouchEvent) => {
     // ズーム後に指1本でパンに移行してガタつくのを防ぐ
     if (touches.length === 0) this.zooming = false
+    this.startMoveToGrid()
   }
 
   private onWheel = (e: WheelEvent) => {
     e.preventDefault()
     this.onZoom(e.clientX, e.clientY, e.deltaY < 0 ? ZOOM_STEP : -ZOOM_STEP)
+    this.stopMoveToGrid()
+
+    if (this.timeoutId) clearTimeout(this.timeoutId)
+    this.timeoutId = setTimeout(this.startMoveToGrid, DELAY_ANIMATION_ON_ZOOM)
   }
 
   private startPan(e: React.MouseEvent | Touch) {
     this.prevPanPoint = { x: e.pageX, y: e.pageY }
+    this.stopMoveToGrid()
   }
 
   private movePan(e: MouseEvent | Touch) {
@@ -122,6 +134,43 @@ export default class InputPanel extends Component<InputPanelProps> {
         Math.min(baseSize.height * (newScale - 1), (zoomCenter.y / scale) * newScale - pinpoint.y)
       )
     })
+  }
+
+  private startMoveToGrid = () => {
+    const { baseSize, gridSize, translate, onChangeFinallyTranslate } = this.props
+    const modX = (translate.x + baseSize.width / 2) % gridSize.width
+    const modY = (translate.y + baseSize.height / 2) % gridSize.height
+
+    onChangeFinallyTranslate({
+      x: translate.x - (modX > gridSize.width / 2 ? modX - gridSize.width : modX),
+      y: translate.y - (modY > gridSize.height / 2 ? modY - gridSize.height : modY)
+    })
+
+    this.animationFrameId = requestAnimationFrame(this.runGridAnimation)
+  }
+
+  private runGridAnimation = () => {
+    const { translate, finallyTranslate } = this.props
+    const step = GRID_ANIMATION_STEP
+    const diffXToGrid = translate.x - finallyTranslate.x
+    const diffYToGrid = translate.y - finallyTranslate.y
+
+    const newDiffX =
+      Math.abs(diffXToGrid) <= step ? 0 : diffXToGrid + (diffXToGrid < 0 ? step : -step)
+    const newDiffY =
+      Math.abs(diffYToGrid) <= step ? 0 : diffYToGrid + (diffYToGrid < 0 ? step : -step)
+
+    this.transform(0, diffXToGrid - newDiffX, diffYToGrid - newDiffY)
+
+    if (newDiffX === 0 && newDiffY === 0) {
+      this.stopMoveToGrid()
+    } else {
+      this.animationFrameId = requestAnimationFrame(this.runGridAnimation)
+    }
+  }
+
+  private stopMoveToGrid() {
+    if (this.animationFrameId) cancelAnimationFrame(this.animationFrameId)
   }
 
   public componentDidMount() {

--- a/frontend/components/viewer/videoContainer.tsx
+++ b/frontend/components/viewer/videoContainer.tsx
@@ -5,9 +5,11 @@ import FrontVideo from './frontVideo'
 
 interface VideoContainerProps {
   playing: boolean
-  baseSize: { width: number; height: number }
   scale: number
+  gridSize: { width: number; height: number }
+  resolutionRatio: number
   translate: { x: number; y: number }
+  finallyTranslate: { x: number; y: number }
 }
 
 interface ContainerProps {
@@ -35,7 +37,7 @@ const BaseVideo = styled.video`
 
 const VideoContainer = (props: VideoContainerProps) => {
   const videoRef = createRef<HTMLVideoElement>()
-  const { playing, baseSize, translate, scale } = props
+  const { playing, translate, scale, gridSize, resolutionRatio, finallyTranslate } = props
   const [currentTime, setCurrentTime] = useState(0)
   const setCurrentTimeOnTimeUpdate = useCallback(
     (e: SyntheticEvent<HTMLVideoElement>) => setCurrentTime(e.currentTarget.currentTime),
@@ -56,9 +58,10 @@ const VideoContainer = (props: VideoContainerProps) => {
       <FrontVideo
         playing={playing}
         currentTime={currentTime}
-        baseSize={baseSize}
         scale={scale}
-        translate={translate}
+        gridSize={gridSize}
+        resolutionRatio={resolutionRatio}
+        finallyTranslate={finallyTranslate}
       />
     </Container>
   )

--- a/frontend/components/viewer/videoContainer.tsx
+++ b/frontend/components/viewer/videoContainer.tsx
@@ -9,7 +9,7 @@ interface VideoContainerProps {
   gridSize: { width: number; height: number }
   resolutionRatio: number
   translate: { x: number; y: number }
-  finallyTranslate: { x: number; y: number }
+  destinationTranslate: { x: number; y: number }
 }
 
 interface ContainerProps {
@@ -37,7 +37,7 @@ const BaseVideo = styled.video`
 
 const VideoContainer = (props: VideoContainerProps) => {
   const videoRef = createRef<HTMLVideoElement>()
-  const { playing, translate, scale, gridSize, resolutionRatio, finallyTranslate } = props
+  const { playing, translate, scale, gridSize, resolutionRatio, destinationTranslate } = props
   const [currentTime, setCurrentTime] = useState(0)
   const setCurrentTimeOnTimeUpdate = useCallback(
     (e: SyntheticEvent<HTMLVideoElement>) => setCurrentTime(e.currentTarget.currentTime),
@@ -61,7 +61,7 @@ const VideoContainer = (props: VideoContainerProps) => {
         scale={scale}
         gridSize={gridSize}
         resolutionRatio={resolutionRatio}
-        finallyTranslate={finallyTranslate}
+        destinationTranslate={destinationTranslate}
       />
     </Container>
   )

--- a/frontend/hooks/viewer/calculateFrontVideoParams.ts
+++ b/frontend/hooks/viewer/calculateFrontVideoParams.ts
@@ -1,21 +1,17 @@
 import { useMemo } from 'react'
 
 export default (
-  baseSize: { width: number; height: number },
+  gridSize: { width: number; height: number },
+  resolutionRatio: number,
   scale: number,
-  translate: { x: number; y: number }
+  finallyTranslate: { x: number; y: number }
 ) =>
   useMemo(() => {
-    const resolutionRatio = scale >= 8 ? 8 : scale >= 4 ? 4 : scale >= 2 ? 2 : 1
-    const blockSize = {
-      width: (baseSize.width * scale) / resolutionRatio / 2,
-      height: (baseSize.height * scale) / resolutionRatio / 2
-    }
-    const left = (translate.x - (translate.x % blockSize.width)) / scale
-    const top = (translate.y - (translate.y % blockSize.height)) / scale
+    const left = (finallyTranslate.x - (finallyTranslate.x % gridSize.width)) / scale
+    const top = (finallyTranslate.y - (finallyTranslate.y % gridSize.height)) / scale
     const src = `${process.env.STORAGE_ORIGIN}/videos/${resolutionRatio}k/${Math.round(
-      (top * scale) / blockSize.height
-    ) + 1}-${Math.round((left * scale) / blockSize.width) + 1}.mp4`
+      (top * scale) / gridSize.height
+    ) + 1}-${Math.round((left * scale) / gridSize.width) + 1}.mp4`
 
-    return { resolutionRatio, top, left, src }
-  }, [baseSize, scale, translate])
+    return { top, left, src }
+  }, [gridSize, finallyTranslate])

--- a/frontend/hooks/viewer/calculateFrontVideoParams.ts
+++ b/frontend/hooks/viewer/calculateFrontVideoParams.ts
@@ -4,14 +4,14 @@ export default (
   gridSize: { width: number; height: number },
   resolutionRatio: number,
   scale: number,
-  finallyTranslate: { x: number; y: number }
+  destinationTranslate: { x: number; y: number }
 ) =>
   useMemo(() => {
-    const left = (finallyTranslate.x - (finallyTranslate.x % gridSize.width)) / scale
-    const top = (finallyTranslate.y - (finallyTranslate.y % gridSize.height)) / scale
+    const left = (destinationTranslate.x - (destinationTranslate.x % gridSize.width)) / scale
+    const top = (destinationTranslate.y - (destinationTranslate.y % gridSize.height)) / scale
     const src = `${process.env.STORAGE_ORIGIN}/videos/${resolutionRatio}k/${Math.round(
       (top * scale) / gridSize.height
     ) + 1}-${Math.round((left * scale) / gridSize.width) + 1}.mp4`
 
     return { top, left, src }
-  }, [gridSize, finallyTranslate])
+  }, [gridSize, destinationTranslate])


### PR DESCRIPTION
- パンやズームのあとにビューワーの中心と解像度に応じたGridの中心を重ねるアニメーションを開始する
- frontVideoがアニメーション途中の影響を受けて無駄な動画をLoadしないように最終的な移動結果をfinallyTranslateで渡す