### PR TITLE
chore: enable bots to auto merge

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -7,6 +7,9 @@ update_configs:
     allowed_updates:
       - match:
           update_type: "security"
+    automerged_updates:
+      - match:
+          update_type: "semver:minor"
     commit_message:
       prefix: "chore"
       include_scope: true

--- a/package.json
+++ b/package.json
@@ -148,18 +148,36 @@
     "npm": {
       "commitMessageTopic": "{{prettyDepType}} {{depName}}",
       "extends": [
-        "group:allNonMajor",
+        ":automergeMinor",
         ":label(dependencies)",
+        ":maintainLockFilesMonthly",
         ":prNotPending",
         ":rebaseStalePrs",
         ":semanticCommitTypeAll(chore)",
         ":semanticCommits",
         ":unpublishSafe"
       ],
-      "lockFileMaintenance": {
-        "enabled": true,
-        "schedule": "after 10am on the first day of the month"
-      },
+      "packageRules": [
+        {
+          "excludePackageNames": [
+            "typescript"
+          ],
+          "minor": {
+            "groupName": "non-major dependencies",
+            "groupSlug": "minor-patch"
+          },
+          "packagePatterns": [
+            "*"
+          ]
+        },
+        {
+          "automerge": false,
+          "description": "Disable auto merging feature",
+          "packageNames": [
+            "typescript"
+          ]
+        }
+      ],
       "prBodyColumns": [
         "Package",
         "Update",


### PR DESCRIPTION
#19 で追加した [Dependabot](https://dependabot.com/) と [Renovate](https://renovatebot.com/) の設定ファイルをオートマージ用に更新しました。  
[TypeScript](https://www.typescriptlang.org/) とメジャーバージョンへの更新を除いたすべてのパッケージが [CircleCI](https://circleci.com/) のテストが成功した場合に自動でマージされます。

[TypeScript](https://www.typescriptlang.org/) については [Visual Studio Code](https://code.visualstudio.com/) とのことや  [SemVer](https://semver.org/) に従っていないことから除外しています。
