### PR TITLE
画像比較ベース処理追加

### DIFF
--- a/frontend/components/slider/comparisonImage.tsx
+++ b/frontend/components/slider/comparisonImage.tsx
@@ -1,14 +1,23 @@
 import React from 'react'
+import styled from 'styled-components'
 
 export interface ComparisonImageProps {
   label?: string
+  left?: number
   src: string
 }
 
-const ComparisonImage = (props: ComparisonImageProps) => <img src={props.src} alt={props.label} />
+const Image = styled.img`
+  max-width: 100%;
+  height: auto;
+  display: block;
+`
+
+const ComparisonImage = (props: ComparisonImageProps) => <Image src={props.src} alt={props.label} />
 
 ComparisonImage.defaultProps = {
-  label: ''
+  label: '',
+  left: 0
 }
 
 export default ComparisonImage

--- a/frontend/components/slider/separator.tsx
+++ b/frontend/components/slider/separator.tsx
@@ -1,0 +1,48 @@
+import React, { useState, useCallback } from 'react'
+import styled from 'styled-components'
+
+export interface SeparatorProps {
+  left: number
+  updateLeft: CallableFunction
+}
+
+const Handle = styled.div`
+  height: 38px;
+  width: 38px;
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  margin-left: -22px;
+  margin-top: -22px;
+  border: 1px solid white;
+  border-radius: 1000px;
+  box-shadow: 0 0 12px rgba(51, 51, 51, 0.5);
+  z-index: 3;
+  background: rgb(0, 0, 0);
+  background: rgba(0, 0, 0, 0.7);
+  cursor: pointer;
+`
+
+const Separator = (props: SeparatorProps) => {
+  const { left, updateLeft } = props
+  const [drag, setDrag] = useState(false)
+  const onMouseMove = useCallback(
+    (e: React.MouseEvent) => {
+      if (drag) updateLeft(e.pageX)
+    },
+    [drag]
+  )
+  const onDrag = useCallback(() => setDrag(true), [])
+  const offDrag = useCallback(() => setDrag(false), [])
+  return (
+    <Handle
+      onMouseDown={onDrag}
+      onMouseMove={onMouseMove}
+      onMouseUp={offDrag}
+      onMouseOut={offDrag}
+      style={{ left }}
+    />
+  )
+}
+
+export default Separator

--- a/frontend/components/slider/sliderContainer.tsx
+++ b/frontend/components/slider/sliderContainer.tsx
@@ -1,5 +1,7 @@
-import React from 'react'
+import React, { useState, useRef, useEffect } from 'react'
+import styled from 'styled-components'
 import ComparisonImage, { ComparisonImageProps } from 'components/slider/comparisonImage'
+import Separator from 'components/slider/separator'
 
 export interface SliderContainerProps {
   aspect?: number
@@ -7,12 +9,51 @@ export interface SliderContainerProps {
   rightImage: ComparisonImageProps
 }
 
+const Wrapper = styled.div`
+  display: inline-block;
+  position: relative;
+  overflow: hidden;
+`
+
+const LeftImage = styled.div`
+  display: block;
+  will-change: clip;
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: 2;
+  pointer-events: none;
+  overflow: hidden;
+`
+
+const RightImage = styled.div`
+  display: block;
+  pointer-events: none;
+`
+
 const SliderContainer = (props: SliderContainerProps) => {
+  const [baseSize, setBaseSize] = useState({ width: 0, height: 0 })
+  const [left, setLeft] = useState(0)
+  const rightImageRef = useRef<HTMLDivElement>(null)
+  const updateLeft = (left: number) => {
+    setLeft(left)
+  }
+  useEffect(() => {
+    const viewerElem = rightImageRef.current!
+    const { clientWidth, clientHeight } = viewerElem
+    setBaseSize({ width: clientWidth, height: clientHeight })
+    setLeft(clientWidth / 2)
+  }, [])
   return (
-    <>
-      <ComparisonImage {...props.leftImage} />
-      <ComparisonImage {...props.rightImage} />
-    </>
+    <Wrapper>
+      <LeftImage style={{ clip: `rect(0, ${left}px, ${baseSize.height}px, 0)` }}>
+        <ComparisonImage {...props.leftImage} />
+      </LeftImage>
+      <Separator left={left} updateLeft={updateLeft} />
+      <RightImage ref={rightImageRef}>
+        <ComparisonImage {...props.rightImage} />
+      </RightImage>
+    </Wrapper>
   )
 }
 


### PR DESCRIPTION
スライダーをドラッグすると写真の境界線を変更する処理を追加しました。
しかし、写真の大きさや比率が異なっていたときの設定やウィンドウサイズの変更には、まだ対応していません。

![画像比較](https://user-images.githubusercontent.com/39573967/65451858-f89e2180-de7a-11e9-8262-e224b77ca463.gif)
